### PR TITLE
add support for timezone variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:22-alpine AS base
 WORKDIR /usr/src/app
 COPY package*.json ./
+RUN apk add --no-cache tzdata
 
 FROM base AS development
 LABEL stage=intermediate

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ In order to run the app, the following configuration options must be set in the 
 | SYNC_ID             | String  |              | The synchronization ID. This can be gathered from Settings → Show advanced settings → Sync ID |
 | SCHEDULE            | String  | 0 0 \* \* \* | The syncing schedule in [cron](https://en.wikipedia.org/wiki/Cron) format                     |
 | RUN_IMMEDIATELY     | Boolean | false        | Determines if a sync job should run immediately after the application starts                  |
+| TZ                  | String  | Etc/UTC      | (optional) Timezone string for container, eg. `Europe/Copenhagen`<br/>This will effect the sync schedule. See [this list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List) for timezone strings. |
 
 ## Usage
 


### PR DESCRIPTION
It may have been my docker configuration, but the container was defaulting to a time zone of `Etc/UTC`. This then meant the scheduled syncs were occurring at an offset to my time zone.

A simple fix is to set a `TZ` environment variable, as NPM seems to pick this up automatically. Additionally, adding the `tzdata` package sets the container shell to the correct time zone, useful for logs outside of NPM.

Example, current commit
```
# docker compose logs
actual-budget-bank-sync  | First job scheduled for 2025-06-06T12:00:00.000+00:00
```

Example: PR commit (with TZ=Europe/London)
```
# docker compose logs
actual-budget-bank-sync  | First job scheduled for 2025-06-06T12:00:00.000+01:00
```

